### PR TITLE
governance: add missing sovereign adoption artifacts

### DIFF
--- a/docs/03_ops/inbound-intake.md
+++ b/docs/03_ops/inbound-intake.md
@@ -1,0 +1,64 @@
+# Inbound Intake — Operations Guide
+
+## Overview
+
+The OpenSIN-overview repository uses an inbound-intake lane to normalize operational work into GitHub issues before any manual triage or repo changes begin.
+
+## Architecture
+
+```
+[External Platform] → [Webhook/Poller] → [Normalize] → [Create GitHub Issue] → [Repo Triage]
+```
+
+## Prerequisites
+
+- n8n running on OCI VM (`http://92.5.60.87:5678`)
+- GitHub Personal Access Token with repo scope
+- `inbound-intake-opensin-overview` workflow imported but inactive until explicitly enabled
+
+## Workflow: `inbound-intake-opensin-overview`
+
+### Trigger
+Webhook POST to `http://92.5.60.87:5678/webhook/inbound-work-opensin-overview`
+
+### Body Schema
+```json
+{
+  "source": "github|telegram|manual|compliance",
+  "type": "bug|enhancement|task|governance",
+  "title": "Work item title",
+  "description": "Detailed description",
+  "priority": "low|medium|high|critical",
+  "metadata": {}
+}
+```
+
+### Steps
+1. Webhook receives incoming payload
+2. Normalize Work Item transforms the payload into the canonical schema
+3. Create GitHub Issue opens a tracker in `OpenSIN-AI/OpenSIN-overview`
+4. Repo triage maps the issue to SSOT, governance, or fleet-board follow-up
+
+## PR Watcher
+
+`scripts/watch-pr-feedback.sh` snapshots the open PR list for this repository and writes watcher state to `/tmp/opensin-pr-watcher`.
+
+## File Locations
+
+| File | Path |
+|------|------|
+| governance contract | `governance/repo-governance.json` |
+| PR watcher contract | `governance/pr-watcher.json` |
+| platform registry | `platforms/registry.json` |
+| n8n workflow | `n8n-workflows/inbound-intake.json` |
+| watcher script | `scripts/watch-pr-feedback.sh` |
+| operations guide | `docs/03_ops/inbound-intake.md` |
+
+## Activation
+
+To activate this lane:
+
+1. Import `n8n-workflows/inbound-intake.json` into n8n
+2. Set the appropriate GitHub credentials in n8n
+3. Register any new intake source in `platforms/registry.json`
+4. Run the PR watcher on a schedule if governance monitoring is needed

--- a/governance/pr-watcher.json
+++ b/governance/pr-watcher.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "repo": "OpenSIN-overview",
+  "org": "OpenSIN-AI",
+  "watcher": {
+    "type": "gh-cli-cron",
+    "script": "scripts/watch-pr-feedback.sh",
+    "fallback": "manual-gh-review"
+  },
+  "reviewChecklist": [
+    "Linked issue or tracker exists",
+    "Governance files remain present",
+    "Markdown and JSON artifacts are valid",
+    "No secrets or credentials were introduced",
+    "Registry and SSOT links remain internally consistent"
+  ],
+  "stopConditions": [
+    "Missing governance artifact",
+    "Invalid JSON in governance or registry files",
+    "Secret material detected in diff"
+  ]
+}

--- a/governance/repo-governance.json
+++ b/governance/repo-governance.json
@@ -1,9 +1,18 @@
 {
-  "version": "1.0",
+  "version": "1.0.0",
   "repo": "OpenSIN-overview",
+  "org": "OpenSIN-AI",
   "rules": {
     "require-pr-watcher": true,
     "require-visual-evidence": true,
-    "fail-closed": true
+    "fail-closed": true,
+    "require-inbound-intake-artifacts": true
+  },
+  "artifacts": {
+    "platformRegistry": "platforms/registry.json",
+    "inboundWorkflow": "n8n-workflows/inbound-intake.json",
+    "watcherScript": "scripts/watch-pr-feedback.sh",
+    "opsGuide": "docs/03_ops/inbound-intake.md",
+    "watcherConfig": "governance/pr-watcher.json"
   }
 }

--- a/n8n-workflows/inbound-intake.json
+++ b/n8n-workflows/inbound-intake.json
@@ -1,0 +1,82 @@
+{
+  "name": "inbound-intake-opensin-overview",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "inbound-work-opensin-overview",
+        "responseMode": "lastNode",
+        "options": {}
+      },
+      "id": "webhook-inbound",
+      "name": "Webhook (Inbound Work)",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ],
+      "webhookId": "inbound-work-opensin-overview"
+    },
+    {
+      "parameters": {
+        "functionCode": "const item = $input.item.json;\nconst owner = item.owner || item.metadata?.owner || process.env.GITHUB_OWNER || 'OpenSIN-AI';\nconst repo = item.repo || item.metadata?.repo || process.env.GITHUB_REPO || 'OpenSIN-overview';\nreturn [{ json: { work_id: item.id || `work-${Date.now()}`, source: item.source || 'unknown', type: item.type || 'task', priority: item.priority || 'medium', title: item.title || 'Untitled', description: item.description || '', metadata: item.metadata || {}, owner, repo, received_at: new Date().toISOString(), status: 'pending' } }];"
+      },
+      "id": "normalize-work",
+      "name": "Normalize Work Item",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        450,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "url": "=https://api.github.com/repos/{{$json.owner}}/{{$json.repo}}/issues",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "method": "POST",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\"title\": $json.title, \"body\": $json.description, \"labels\": [$json.type]}",
+        "options": {}
+      },
+      "id": "create-github-issue",
+      "name": "Create GitHub Issue",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        650,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Webhook (Inbound Work)": {
+      "main": [
+        [
+          {
+            "node": "Normalize Work Item",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize Work Item": {
+      "main": [
+        [
+          {
+            "node": "Create GitHub Issue",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {},
+  "id": "inbound-intake-opensin-overview"
+}

--- a/platforms/registry.json
+++ b/platforms/registry.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.0.0",
+  "updated_at": "2026-04-18",
+  "repo": "OpenSIN-overview",
+  "platforms": [
+    {
+      "id": "github",
+      "type": "repo_events",
+      "status": "active",
+      "intake": {
+        "mode": "webhook",
+        "path": "n8n-workflows/inbound-intake.json"
+      },
+      "watcher": {
+        "script": "scripts/watch-pr-feedback.sh"
+      }
+    }
+  ]
+}

--- a/scripts/watch-pr-feedback.sh
+++ b/scripts/watch-pr-feedback.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_OWNER=${REPO_OWNER:-OpenSIN-AI}
+REPO_NAME=${REPO_NAME:-OpenSIN-overview}
+PR_LIMIT=${PR_LIMIT:-20}
+STATE_DIR=${STATE_DIR:-/tmp/opensin-pr-watcher}
+
+mkdir -p "$STATE_DIR"
+OUT="$STATE_DIR/${REPO_OWNER}-${REPO_NAME}-pr-feedback.json"
+
+python3 - "$REPO_OWNER" "$REPO_NAME" "$PR_LIMIT" "$OUT" <<'INNER'
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+owner, repo, limit, out_path = sys.argv[1:5]
+result = subprocess.run([
+    'gh', 'pr', 'list',
+    '--repo', f'{owner}/{repo}',
+    '--state', 'open',
+    '--limit', limit,
+    '--json', 'number,title,updatedAt'
+], capture_output=True, text=True, check=True)
+
+out = Path(out_path)
+out.write_text(result.stdout)
+items = json.loads(result.stdout or '[]')
+summary = {
+    'open_prs': len(items),
+    'latest_updated_at': items[0]['updatedAt'] if items else None,
+    'titles': [item['title'] for item in items[:5]],
+}
+print(json.dumps(summary, indent=2))
+INNER


### PR DESCRIPTION
## Summary
- add the missing sovereign governance artifacts that issue #26 claimed were already present
- wire OpenSIN-overview to a repo-level PR watcher contract, platform registry, inbound intake workflow, and ops guide
- upgrade the existing governance contract to reference the newly added rollout artifacts

## Validation
- validated JSON for governance, registry, and n8n workflow files with `python3 -c 'import json'`
- validated `scripts/watch-pr-feedback.sh` with `bash -n`
