### PR TITLE
docs(ssot): add START-HERE.md + canonical repo map + April 2026 consolidation report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> ## NEU HIER? → **[START-HERE.md](./START-HERE.md)**
+>
+> **In 60 Sekunden handlungsfähig** — für menschliche Entwickler UND AI-Agenten.
+>
+> Konsolidierung April 2026 (9 → 4 Code-Repos): [docs/CONSOLIDATION-2026-04.md](./docs/CONSOLIDATION-2026-04.md)
+> Kanonische Repo-Zuordnung: [docs/CANONICAL-REPOS.md](./docs/CANONICAL-REPOS.md)
+
+---
+
 # 🦅 OPENSIN-AI: KOMPAKT-ÜBERSICHT
 
 > **The Ultimate Single Source of Truth für die OpenSIN-AI Organisation**

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -1,0 +1,79 @@
+# START HERE
+
+> **Wer das hier liest — Mensch oder Agent — ist in unter 60 Sekunden handlungsfähig.**
+
+You just landed in the OpenSIN-AI organization (195 repos, 17 teams, 149 workers).
+Read this file first. Then one more. Then you're working.
+
+---
+
+## 1. Du bist ein menschlicher Entwickler?
+
+Lies in dieser Reihenfolge:
+
+1. **[docs/CANONICAL-REPOS.md](./docs/CANONICAL-REPOS.md)** — welches Repo ist wofür zuständig. **Open keinen PR ohne diese Datei.**
+2. **[README.md](./README.md)** — die volle Ökosystem-Übersicht (Teams, Worker, Standards, CI).
+3. **[AGENTS.md](./AGENTS.md)** — Entwicklungs-Guidelines.
+4. **[governance/BOUNDARY-ROLE-RULES.md](./governance/BOUNDARY-ROLE-RULES.md)** — was welches Repo *nicht* sein darf.
+
+Setup in 3 Befehlen:
+```bash
+gh auth login
+gh repo clone OpenSIN-AI/OpenSIN      # Python-Kernel
+gh repo clone OpenSIN-AI/OpenSIN-Code # TypeScript CLI
+```
+
+---
+
+## 2. Du bist ein AI-Agent?
+
+Lies in dieser Reihenfolge:
+
+1. **`docs/CANONICAL-REPOS.md`** — pflichtlektüre. Niemals in archivierten Repos arbeiten.
+2. **`registry/MASTER_INDEX.md`** — der maschinenlesbare Index aller Repos.
+3. **`platforms/registry.json`** — strukturierte Repo-Liste.
+4. **`AGENTS.md`** + **`governance/BOUNDARY-ROLE-RULES.md`** — Regeln, die du befolgen musst.
+
+Vor jedem Task: `discover-agents.js` ausführen (siehe Routing-Regeln in `opencode.json` bei Delqhi/upgraded-opencode-stack).
+
+---
+
+## 3. Die 4 kanonischen Code-Repos (nach der April-2026-Konsolidierung)
+
+| Repo | Zweck | Sprache |
+|---|---|---|
+| [OpenSIN](https://github.com/OpenSIN-AI/OpenSIN) | **Python-Kernel** — `opensin_core`, `opensin_cli`, `opensin_api`, `opensin_sdk` | Python |
+| [OpenSIN-Code](https://github.com/OpenSIN-AI/OpenSIN-Code) | **Autonome TypeScript CLI** (Claude-Code-Klasse) | TypeScript |
+| [OpenSIN-backend](https://github.com/OpenSIN-AI/OpenSIN-backend) | **A2A Fleet Control Plane** — orchestriert die Agenten-Flotte | TypeScript |
+| [Team-SIN-Code-Core](https://github.com/OpenSIN-AI/Team-SIN-Code-Core) | **Coding-Team Monorepo** — Team-Manager + `agents/coding-ceo` + `agents/code-ai` | TypeScript |
+
+Plus zwei Meta-Repos:
+
+| Repo | Zweck |
+|---|---|
+| [OpenSIN-overview](https://github.com/OpenSIN-AI/OpenSIN-overview) | **Das hier** — SSOT für alle 195 Repos, Onboarding |
+| [OpenSIN-documentation](https://github.com/OpenSIN-AI/OpenSIN-documentation) | **docs.opensin.ai** — die öffentliche Doku-Website |
+
+---
+
+## 4. Archivierte Repos — NICHT mehr verwenden
+
+Diese Repos sind **read-only** und wurden in andere Repos konsolidiert.
+Öffne hier keine PRs. Öffne keine Issues. Clone sie nicht.
+
+| Archiviert | Weiterleitung |
+|---|---|
+| `A2A-SIN-Coding-CEO` | → `Team-SIN-Code-Core/agents/coding-ceo/` |
+| `A2A-SIN-Code-AI`    | → `Team-SIN-Code-Core/agents/code-ai/` |
+| `opensin-ai-code`    | → `OpenSIN/opensin_agent_platform/` |
+
+Details: [docs/CONSOLIDATION-2026-04.md](./docs/CONSOLIDATION-2026-04.md)
+
+---
+
+## 5. Eine Regel
+
+**Jede Unklarheit "wo gehört das hin?" wird in diesem Repo geklärt — und zwar BEVOR Code geschrieben wird.**
+
+Dieses Repo ist die Single Source of Truth für die Organisations-Topologie.
+Wenn die Topologie hier falsch dokumentiert ist, ist *das* der Bug — nicht der Code.

--- a/docs/CANONICAL-REPOS.md
+++ b/docs/CANONICAL-REPOS.md
@@ -1,0 +1,91 @@
+# Canonical Repos — Authoritative Map
+
+> **State: April 2026, post-consolidation.**
+> If you open a PR against a repo that is marked `ARCHIVED` below, it will not be reviewed.
+
+This document is the **single source of truth** for which repository owns which
+responsibility in OpenSIN-AI. When new code is written, it goes into the repo
+listed here as the canonical owner of that concern — not a duplicate.
+
+## Code repos
+
+### OpenSIN — Python Kernel
+
+**URL:** https://github.com/OpenSIN-AI/OpenSIN
+**Language:** Python
+**Owns:**
+
+- `opensin_core/` — QueryEngine, Hook System, Tool System, Permission System, MCP Client, Sandbox, Memory, Sessions
+- `opensin_cli/` — the `opensin` command-line tool
+- `opensin_api/` — HTTP API server
+- `opensin_sdk/` — Python SDK for programmatic access
+- `opensin_agent_platform/` — absorbed content from the archived `opensin-ai-code` repo; reference material only, not yet wired into the build
+
+**Do not** open a new `opensin_*` package outside this repo.
+
+### OpenSIN-Code — Autonomous TypeScript CLI
+
+**URL:** https://github.com/OpenSIN-AI/OpenSIN-Code
+**Language:** TypeScript
+**Owns:** the Claude-Code-class autonomous coding CLI. Standalone binary.
+
+Distinct from the Python CLI at `OpenSIN/opensin_cli/`. They address different
+use cases — Python CLI is for scripting the kernel, this one is a full
+terminal coding agent.
+
+### OpenSIN-backend — A2A Fleet Control Plane
+
+**URL:** https://github.com/OpenSIN-AI/OpenSIN-backend
+**Language:** TypeScript
+**Owns:** the control plane that orchestrates the agent-to-agent fleet at runtime.
+
+### Team-SIN-Code-Core — Coding Team Monorepo
+
+**URL:** https://github.com/OpenSIN-AI/Team-SIN-Code-Core
+**Language:** TypeScript (pnpm workspace)
+**Owns:**
+
+- Root — Team Manager / orchestrator for the coding team
+- `agents/coding-ceo/` — the Coding-CEO agent (was `A2A-SIN-Coding-CEO`)
+- `agents/code-ai/` — the Code-AI agent (was `A2A-SIN-Code-AI`)
+- `packages/shared-helpers/` — `@opensin/shared-helpers` workspace package
+
+All future coding-team agents (`code-devops`, `code-datascience`, ...)
+are added as new folders under `agents/`. **Do not spin up a new repo for them.**
+
+## Meta repos
+
+### OpenSIN-overview — Organizational SSOT
+
+**URL:** https://github.com/OpenSIN-AI/OpenSIN-overview (this repo)
+**Owns:** onboarding, repo registry, boundary rules, consolidation reports.
+**Does not own:** any production code. Link to owning repos for runtime/docs/product/control-plane details.
+
+### OpenSIN-documentation — Public Docs Website
+
+**URL:** https://github.com/OpenSIN-AI/OpenSIN-documentation
+**Serves:** https://docs.opensin.ai
+**Owns:** all user-facing documentation (guides, tutorials, API reference).
+
+## Archived repos
+
+| Repo | Status | Canonical replacement |
+|---|---|---|
+| `OpenSIN-AI/A2A-SIN-Coding-CEO` | ARCHIVED | `Team-SIN-Code-Core/agents/coding-ceo/` |
+| `OpenSIN-AI/A2A-SIN-Code-AI`    | ARCHIVED | `Team-SIN-Code-Core/agents/code-ai/` |
+| `OpenSIN-AI/opensin-ai-code`    | ARCHIVED | `OpenSIN/opensin_agent_platform/` |
+
+These repos stay on GitHub in read-only state for history. Their READMEs point here.
+
+## How to propose a new code repo
+
+Before creating any new `OpenSIN-AI/*` repo, open an issue in **this** repo
+titled `repo-proposal: <name>` answering:
+
+1. What responsibility does this repo own that no existing canonical repo owns?
+2. Why can it not be a folder inside one of the canonical repos?
+3. Who maintains it?
+
+If the answer to (2) is not clearly "because it must be deployed independently
+with its own release cycle and a different language or runtime," the answer
+is usually: **make it a folder, not a repo.**

--- a/docs/CONSOLIDATION-2026-04.md
+++ b/docs/CONSOLIDATION-2026-04.md
@@ -1,0 +1,78 @@
+# Consolidation Report — April 2026
+
+## Problem
+
+The OpenSIN-AI organization had accumulated multiple repos that all claimed
+to be "the coding / agent platform." Concretely:
+
+- Three repos for the coding-team agents (`Team-SIN-Code-Core`,
+  `A2A-SIN-Coding-CEO`, `A2A-SIN-Code-AI`) that only differed in the
+  model name in `agent.json` and shared a `workspace:*` dependency that
+  could never resolve across repo boundaries.
+- A separate `opensin-ai-code` Python repo that duplicated the ground
+  already covered by `OpenSIN/opensin_core` / `opensin_cli` / `opensin_sdk`,
+  and which advertised a `pip install opensin-ai-code` path that never
+  actually worked (no `pyproject.toml`).
+
+Result: new contributors (human and agent) could not tell where new code
+should go, and cross-repo workspace dependencies were fundamentally broken.
+
+## Actions taken
+
+### 1. Coding-team monorepo
+Merged into `OpenSIN-AI/Team-SIN-Code-Core`:
+- `A2A-SIN-Coding-CEO` → `agents/coding-ceo/`
+- `A2A-SIN-Code-AI` → `agents/code-ai/`
+
+Added `pnpm-workspace.yaml`, `packages/shared-helpers/` (the previously
+missing workspace:* target), and `start:coding-ceo` / `start:code-ai`
+scripts in the root `package.json`.
+
+PR: https://github.com/OpenSIN-AI/Team-SIN-Code-Core/pull/2
+
+### 2. Python platform merge
+Merged `opensin-ai-code` into `OpenSIN` as `opensin_agent_platform/`.
+Folder is preserved as reference material with a follow-up rationalization
+plan documented in its README. Not yet wired into the production build.
+
+PR: https://github.com/OpenSIN-AI/OpenSIN/pull/1720
+
+### 3. Onboarding SSOT
+Sharpened `OpenSIN-overview` with:
+- `START-HERE.md` — 60-second onboarding for humans and agents
+- `docs/CANONICAL-REPOS.md` — authoritative repo-ownership map
+- This report
+
+### 4. Archival
+After the two PRs above merge, the following repos are archived with a
+redirect README:
+- `OpenSIN-AI/A2A-SIN-Coding-CEO`
+- `OpenSIN-AI/A2A-SIN-Code-AI`
+- `OpenSIN-AI/opensin-ai-code`
+
+## Result
+
+From 9 confusing repos with overlapping claims to 4 code repos + 2 meta
+repos with clearly separated ownership:
+
+| Before | After |
+|---|---|
+| OpenSIN | OpenSIN (unchanged role) |
+| OpenSIN-Code | OpenSIN-Code (unchanged role) |
+| OpenSIN-backend | OpenSIN-backend (unchanged role) |
+| Team-SIN-Code-Core | Team-SIN-Code-Core (now monorepo) |
+| A2A-SIN-Coding-CEO | archived → `Team-SIN-Code-Core/agents/coding-ceo` |
+| A2A-SIN-Code-AI | archived → `Team-SIN-Code-Core/agents/code-ai` |
+| opensin-ai-code | archived → `OpenSIN/opensin_agent_platform` |
+| OpenSIN-overview | OpenSIN-overview (now with START-HERE.md) |
+| OpenSIN-documentation | OpenSIN-documentation (unchanged role) |
+
+## Follow-ups
+
+1. Diff `OpenSIN/opensin_agent_platform/` against `OpenSIN/opensin_core/`
+   (both have `hooks`, `plugins`, `skills` modules). Port any genuinely
+   useful logic into `opensin_core` and retire the folder.
+2. Extend `Team-SIN-Code-Core` with `agents/code-devops/` and
+   `agents/code-datascience/` instead of creating new repos for them.
+3. Run `discover-agents.js` and `registry/MASTER_INDEX.md` regeneration
+   so the indexes reflect the new layout.


### PR DESCRIPTION
## Summary

Turns this repo into an instantly-useful entrypoint for **every new contributor** — human developer or AI agent — after the April 2026 repo consolidation (9 -> 4 code repos).

## New files

- **`START-HERE.md`** — 60-second onboarding. Separate paths for humans and agents. Lists the 4 canonical code repos and the 3 archived ones.
- **`docs/CANONICAL-REPOS.md`** — authoritative ownership map. States explicitly which repo owns what, and includes a "how to propose a new code repo" gate.
- **`docs/CONSOLIDATION-2026-04.md`** — what was merged into what, with PR links and follow-ups.

## Changes to README

Pinned banner added at the very top pointing to the three files above.
**No existing content is removed or reordered** — the banner sits in front of the current README.

## Why it matters

After today's consolidation:
- `A2A-SIN-Coding-CEO` → `Team-SIN-Code-Core/agents/coding-ceo/`
- `A2A-SIN-Code-AI` → `Team-SIN-Code-Core/agents/code-ai/`
- `opensin-ai-code` → `OpenSIN/opensin_agent_platform/`

Without these docs, a freshly-spawned agent or a new dev could still open a PR against one of the archived repos. With them, the path is unambiguous in 60 seconds.

Related PRs:
- https://github.com/OpenSIN-AI/Team-SIN-Code-Core/pull/2
- https://github.com/OpenSIN-AI/OpenSIN/pull/1720

Co-authored-by: v0[bot] <v0[bot]@users.noreply.github.com>