### PR TITLE
docs(ssot): expand canonical map + naming convention + wave-2 consolidation log

### DIFF
--- a/START-HERE.md
+++ b/START-HERE.md
@@ -3,7 +3,7 @@
 > **Wer das hier liest — Mensch oder Agent — ist in unter 60 Sekunden handlungsfähig.**
 
 You just landed in the OpenSIN-AI organization (195 repos, 17 teams, 149 workers).
-Read this file first. Then one more. Then you're working.
+Read this file first. Then [`docs/CANONICAL-REPOS.md`](./docs/CANONICAL-REPOS.md). Then you're working.
 
 ---
 
@@ -11,16 +11,16 @@ Read this file first. Then one more. Then you're working.
 
 Lies in dieser Reihenfolge:
 
-1. **[docs/CANONICAL-REPOS.md](./docs/CANONICAL-REPOS.md)** — welches Repo ist wofür zuständig. **Open keinen PR ohne diese Datei.**
-2. **[README.md](./README.md)** — die volle Ökosystem-Übersicht (Teams, Worker, Standards, CI).
-3. **[AGENTS.md](./AGENTS.md)** — Entwicklungs-Guidelines.
-4. **[governance/BOUNDARY-ROLE-RULES.md](./governance/BOUNDARY-ROLE-RULES.md)** — was welches Repo *nicht* sein darf.
+1. **[docs/CANONICAL-REPOS.md](./docs/CANONICAL-REPOS.md)** — authoritative map of which repo owns what. **Niemals einen PR öffnen, ohne vorher diese Datei gelesen zu haben.**
+2. **[README.md](./README.md)** — full ecosystem overview (teams, workers, standards, CI).
+3. **[AGENTS.md](./AGENTS.md)** — development guidelines.
+4. **[governance/BOUNDARY-ROLE-RULES.md](./governance/BOUNDARY-ROLE-RULES.md)** — what each repo must *not* be.
 
-Setup in 3 Befehlen:
+Setup in drei Befehlen:
 ```bash
 gh auth login
-gh repo clone OpenSIN-AI/OpenSIN      # Python-Kernel
-gh repo clone OpenSIN-AI/OpenSIN-Code # TypeScript CLI
+gh repo clone OpenSIN-AI/Infra-SIN-Dev-Setup   # dev + user-onboarding setup
+gh repo clone OpenSIN-AI/OpenSIN               # Python-Kernel
 ```
 
 ---
@@ -29,30 +29,62 @@ gh repo clone OpenSIN-AI/OpenSIN-Code # TypeScript CLI
 
 Lies in dieser Reihenfolge:
 
-1. **`docs/CANONICAL-REPOS.md`** — pflichtlektüre. Niemals in archivierten Repos arbeiten.
-2. **`registry/MASTER_INDEX.md`** — der maschinenlesbare Index aller Repos.
-3. **`platforms/registry.json`** — strukturierte Repo-Liste.
-4. **`AGENTS.md`** + **`governance/BOUNDARY-ROLE-RULES.md`** — Regeln, die du befolgen musst.
+1. **`docs/CANONICAL-REPOS.md`** — Pflichtlektüre. Niemals in archivierten Repos arbeiten.
+2. **`registry/MASTER_INDEX.md`** — the machine-readable index of all repos.
+3. **`platforms/registry.json`** — structured repo list.
+4. **`AGENTS.md`** + **`governance/BOUNDARY-ROLE-RULES.md`** — rules you must follow.
 
-Vor jedem Task: `discover-agents.js` ausführen (siehe Routing-Regeln in `opencode.json` bei Delqhi/upgraded-opencode-stack).
+Vor jedem Task: `discover-agents.js` ausführen (Routing-Regeln siehe `opencode.json` bei `Delqhi/upgraded-opencode-stack` — which is the external SSOT for OpenCode config; see CANONICAL-REPOS.md § 8).
 
 ---
 
-## 3. Die 4 kanonischen Code-Repos (nach der April-2026-Konsolidierung)
+## 3. Die Repos nach Domäne (kanonisch, Stand 2026-04-18)
 
+### Kern-Plattform (keine Präfixe)
 | Repo | Zweck | Sprache |
 |---|---|---|
-| [OpenSIN](https://github.com/OpenSIN-AI/OpenSIN) | **Python-Kernel** — `opensin_core`, `opensin_cli`, `opensin_api`, `opensin_sdk` | Python |
-| [OpenSIN-Code](https://github.com/OpenSIN-AI/OpenSIN-Code) | **Autonome TypeScript CLI** (Claude-Code-Klasse) | TypeScript |
-| [OpenSIN-backend](https://github.com/OpenSIN-AI/OpenSIN-backend) | **A2A Fleet Control Plane** — orchestriert die Agenten-Flotte | TypeScript |
-| [Team-SIN-Code-Core](https://github.com/OpenSIN-AI/Team-SIN-Code-Core) | **Coding-Team Monorepo** — Team-Manager + `agents/coding-ceo` + `agents/code-ai` | TypeScript |
+| [OpenSIN](https://github.com/OpenSIN-AI/OpenSIN) | **Python-Kernel** — `opensin_core`, `opensin_cli`, `opensin_api`, `opensin_sdk`, `opensin_agent_platform` | Python |
+| [OpenSIN-Code](https://github.com/OpenSIN-AI/OpenSIN-Code) | **Autonome TypeScript CLI** (Claude-Code-Klasse) — **nicht** eine VS Code Extension | TypeScript |
+| [OpenSIN-backend](https://github.com/OpenSIN-AI/OpenSIN-backend) | **A2A Fleet Control Plane** | TypeScript |
+| [OpenSIN-WebApp](https://github.com/OpenSIN-AI/OpenSIN-WebApp) | **Authenticated dashboard** at `chat.opensin.ai` (Paket: `opensin-chat`) | TypeScript / Next.js |
 
-Plus zwei Meta-Repos:
+### Web-Oberfläche
+| Repo | Deployed at | Typ |
+|---|---|---|
+| [website-opensin.ai](https://github.com/OpenSIN-AI/website-opensin.ai) | `opensin.ai` | Open-Source Marketing |
+| [website-my.opensin.ai](https://github.com/OpenSIN-AI/website-my.opensin.ai) | `my.opensin.ai` | Paid-Layer Marketing / Marketplace |
 
+### Team-Monorepos (`Team-SIN-*`)
 | Repo | Zweck |
 |---|---|
-| [OpenSIN-overview](https://github.com/OpenSIN-AI/OpenSIN-overview) | **Das hier** — SSOT für alle 195 Repos, Onboarding |
-| [OpenSIN-documentation](https://github.com/OpenSIN-AI/OpenSIN-documentation) | **docs.opensin.ai** — die öffentliche Doku-Website |
+| [Team-SIN-Code-Core](https://github.com/OpenSIN-AI/Team-SIN-Code-Core) | Coding team — Team Manager + `agents/coding-ceo` + `agents/code-ai` |
+
+### Infrastruktur (`Infra-SIN-*`)
+| Repo | Zweck |
+|---|---|
+| [Infra-SIN-Dev-Setup](https://github.com/OpenSIN-AI/Infra-SIN-Dev-Setup) | Dev environment setup + end-user first-run onboarding (`user-onboarding/`) |
+
+### Templates (`Template-SIN-*`)
+| Repo | Zweck |
+|---|---|
+| [Template-SIN-Agent](https://github.com/OpenSIN-AI/Template-SIN-Agent) | Starting point for any new A2A agent |
+
+### Business / Marketing (`Biz-SIN-*`)
+| Repo | Zweck |
+|---|---|
+| [Biz-SIN-Marketing](https://github.com/OpenSIN-AI/Biz-SIN-Marketing) | Launch hub, blog posts, press release, community strategy |
+
+### Doku & Meta
+| Repo | Zweck |
+|---|---|
+| [OpenSIN-overview](https://github.com/OpenSIN-AI/OpenSIN-overview) | **Dieses Repo** — SSOT für alle Org-Repos, Onboarding, Governance |
+| [OpenSIN-documentation](https://github.com/OpenSIN-AI/OpenSIN-documentation) | `docs.opensin.ai` — end-user documentation |
+
+### Externe SSOT (noch in @Delqhi — sollten transferiert werden)
+| Repo | Rolle |
+|---|---|
+| [Delqhi/upgraded-opencode-stack](https://github.com/Delqhi/upgraded-opencode-stack) | Kanonische OpenCode-Konfiguration (sin-sync Target) |
+| [Delqhi/global-brain](https://github.com/Delqhi/global-brain) | PCPM v4 daemon (persistent agent memory) |
 
 ---
 
@@ -66,14 +98,23 @@ Diese Repos sind **read-only** und wurden in andere Repos konsolidiert.
 | `A2A-SIN-Coding-CEO` | → `Team-SIN-Code-Core/agents/coding-ceo/` |
 | `A2A-SIN-Code-AI`    | → `Team-SIN-Code-Core/agents/code-ai/` |
 | `opensin-ai-code`    | → `OpenSIN/opensin_agent_platform/` |
+| `OpenSIN-onboarding` | → `Infra-SIN-Dev-Setup/user-onboarding/` |
 
 Details: [docs/CONSOLIDATION-2026-04.md](./docs/CONSOLIDATION-2026-04.md)
 
 ---
 
-## 5. Eine Regel
+## 5. Naming convention in 2 Sätzen
+
+- **Flagship / Produkt-Namen:** kein Präfix (`OpenSIN`, `OpenSIN-Code`, `OpenSIN-backend`, `OpenSIN-WebApp`, `website-opensin.ai`, `website-my.opensin.ai`).
+- **Supporting-Artefakte:** Domain-Präfix (`Team-SIN-*`, `Infra-SIN-*`, `Biz-SIN-*`, `Template-SIN-*`).
+
+Volle Regeln: [docs/CANONICAL-REPOS.md § Naming convention](./docs/CANONICAL-REPOS.md#naming-convention).
+
+---
+
+## 6. Eine Regel
 
 **Jede Unklarheit "wo gehört das hin?" wird in diesem Repo geklärt — und zwar BEVOR Code geschrieben wird.**
 
-Dieses Repo ist die Single Source of Truth für die Organisations-Topologie.
-Wenn die Topologie hier falsch dokumentiert ist, ist *das* der Bug — nicht der Code.
+Dieses Repo ist die Single Source of Truth für die Organisations-Topologie. Wenn die Topologie hier falsch dokumentiert ist, ist *das* der Bug — nicht der Code.

--- a/docs/CANONICAL-REPOS.md
+++ b/docs/CANONICAL-REPOS.md
@@ -1,91 +1,203 @@
 # Canonical Repos — Authoritative Map
 
-> **State: April 2026, post-consolidation.**
-> If you open a PR against a repo that is marked `ARCHIVED` below, it will not be reviewed.
+> **State:** 2026-04-18, post-consolidation wave 2.
+> If you open a PR against a repo marked `ARCHIVED` below, it will not be reviewed.
 
-This document is the **single source of truth** for which repository owns which
-responsibility in OpenSIN-AI. When new code is written, it goes into the repo
-listed here as the canonical owner of that concern — not a duplicate.
+This document is the **single source of truth** for which repository in the
+`OpenSIN-AI` organization (and a small number of external repos) owns which
+responsibility. When new code is written, it goes into the repo listed here
+as the canonical owner of that concern — not a duplicate, not a new repo.
 
-## Code repos
+Repos are grouped by domain. Every entry states: URL, actual GitHub name
+(in case you knew it by an old alias), the owned surface, and any `DO NOT`
+rules.
 
-### OpenSIN — Python Kernel
+---
 
-**URL:** https://github.com/OpenSIN-AI/OpenSIN
-**Language:** Python
-**Owns:**
+## 1. Core platform (Python)
 
-- `opensin_core/` — QueryEngine, Hook System, Tool System, Permission System, MCP Client, Sandbox, Memory, Sessions
-- `opensin_cli/` — the `opensin` command-line tool
-- `opensin_api/` — HTTP API server
-- `opensin_sdk/` — Python SDK for programmatic access
-- `opensin_agent_platform/` — absorbed content from the archived `opensin-ai-code` repo; reference material only, not yet wired into the build
+### OpenSIN — Python kernel
+- **URL:** https://github.com/OpenSIN-AI/OpenSIN
+- **Domain prefix:** none (flagship repo, keeps the product name)
+- **Owns:**
+  - `opensin_core/` — QueryEngine, Hook System, Tool System, Permission System, MCP Client, Sandbox, Memory, Sessions
+  - `opensin_cli/` — the `opensin` command-line tool
+  - `opensin_api/` — HTTP API server
+  - `opensin_sdk/` — Python SDK for programmatic access
+  - `opensin_agent_platform/` — absorbed content from the archived `opensin-ai-code` repo (reference material; not wired into the build yet)
+- **Do not:** open a new `opensin_*` package outside this repo.
 
-**Do not** open a new `opensin_*` package outside this repo.
+---
 
-### OpenSIN-Code — Autonomous TypeScript CLI
+## 2. Autonomous coding surface (TypeScript)
 
-**URL:** https://github.com/OpenSIN-AI/OpenSIN-Code
-**Language:** TypeScript
-**Owns:** the Claude-Code-class autonomous coding CLI. Standalone binary.
+### OpenSIN-Code — Autonomous CLI
+- **URL:** https://github.com/OpenSIN-AI/OpenSIN-Code
+- **Domain prefix:** none
+- **Owns:** the Claude-Code-class autonomous coding CLI. Standalone binary.
+- **Not:** a VS Code extension. Any README that calls this a "VS Code Extension" is wrong.
 
-Distinct from the Python CLI at `OpenSIN/opensin_cli/`. They address different
-use cases — Python CLI is for scripting the kernel, this one is a full
-terminal coding agent.
+### OpenSIN-backend — A2A fleet control plane
+- **URL:** https://github.com/OpenSIN-AI/OpenSIN-backend
+- **Domain prefix:** none
+- **Owns:** the runtime control plane that orchestrates the agent fleet at runtime.
 
-### OpenSIN-backend — A2A Fleet Control Plane
+### Team-SIN-Code-Core — Coding-team monorepo
+- **URL:** https://github.com/OpenSIN-AI/Team-SIN-Code-Core
+- **Domain prefix:** `Team-SIN-*`
+- **Owns:**
+  - Root — Team Manager / orchestrator for the coding team
+  - `agents/coding-ceo/` — the Coding-CEO agent (was `A2A-SIN-Coding-CEO`, archived)
+  - `agents/code-ai/` — the Code-AI agent (was `A2A-SIN-Code-AI`, archived)
+  - `packages/shared-helpers/` — `@opensin/shared-helpers` workspace package
+- **Do not:** spin up a new repo for future coding-team agents (`code-devops`, `code-datascience`, ...). Add them as new folders under `agents/`.
 
-**URL:** https://github.com/OpenSIN-AI/OpenSIN-backend
-**Language:** TypeScript
-**Owns:** the control plane that orchestrates the agent-to-agent fleet at runtime.
+### Template-SIN-Agent — Agent blueprint
+- **URL:** https://github.com/OpenSIN-AI/Template-SIN-Agent (was `Template-A2A-SIN-Agent`)
+- **Domain prefix:** `Template-SIN-*`
+- **Owns:** the standardized starting point for any new A2A agent. Merged three earlier templates (Agent, Agent-Worker, Worker) into one.
+- **Use:** when you need a brand-new agent that does NOT fit into `Team-SIN-Code-Core`.
 
-### Team-SIN-Code-Core — Coding Team Monorepo
+---
 
-**URL:** https://github.com/OpenSIN-AI/Team-SIN-Code-Core
-**Language:** TypeScript (pnpm workspace)
-**Owns:**
+## 3. Web surface (TypeScript)
 
-- Root — Team Manager / orchestrator for the coding team
-- `agents/coding-ceo/` — the Coding-CEO agent (was `A2A-SIN-Coding-CEO`)
-- `agents/code-ai/` — the Code-AI agent (was `A2A-SIN-Code-AI`)
-- `packages/shared-helpers/` — `@opensin/shared-helpers` workspace package
+Three repos for three distinct properties. Do not confuse them.
 
-All future coding-team agents (`code-devops`, `code-datascience`, ...)
-are added as new folders under `agents/`. **Do not spin up a new repo for them.**
-
-## Meta repos
-
-### OpenSIN-overview — Organizational SSOT
-
-**URL:** https://github.com/OpenSIN-AI/OpenSIN-overview (this repo)
-**Owns:** onboarding, repo registry, boundary rules, consolidation reports.
-**Does not own:** any production code. Link to owning repos for runtime/docs/product/control-plane details.
-
-### OpenSIN-documentation — Public Docs Website
-
-**URL:** https://github.com/OpenSIN-AI/OpenSIN-documentation
-**Serves:** https://docs.opensin.ai
-**Owns:** all user-facing documentation (guides, tutorials, API reference).
-
-## Archived repos
-
-| Repo | Status | Canonical replacement |
+| Repo | Deployed at | Purpose |
 |---|---|---|
-| `OpenSIN-AI/A2A-SIN-Coding-CEO` | ARCHIVED | `Team-SIN-Code-Core/agents/coding-ceo/` |
-| `OpenSIN-AI/A2A-SIN-Code-AI`    | ARCHIVED | `Team-SIN-Code-Core/agents/code-ai/` |
-| `OpenSIN-AI/opensin-ai-code`    | ARCHIVED | `OpenSIN/opensin_agent_platform/` |
+| [`website-opensin.ai`](https://github.com/OpenSIN-AI/website-opensin.ai) | `opensin.ai` | **Open-source marketing site.** Developers, self-hosters, community. Static Vite/Bun site. |
+| [`website-my.opensin.ai`](https://github.com/OpenSIN-AI/website-my.opensin.ai) | `my.opensin.ai` | **Paid-layer marketing + marketplace.** Team packages, bundles, conversion funnel. Static Vite/Bun site. |
+| [`OpenSIN-WebApp`](https://github.com/OpenSIN-AI/OpenSIN-WebApp) (package: `opensin-chat`) | `chat.opensin.ai` | **Authenticated dashboard.** Login, agent fleet, chat, api-keys, billing. Next.js 16 + Supabase. **Private repo** — contains business logic. |
 
-These repos stay on GitHub in read-only state for history. Their READMEs point here.
+**Rule of thumb:**
+- Anonymous visitor → `website-opensin.ai` or `website-my.opensin.ai`
+- Logged-in user → `OpenSIN-WebApp`
+
+---
+
+## 4. Documentation
+
+### OpenSIN-documentation — Public docs website
+- **URL:** https://github.com/OpenSIN-AI/OpenSIN-documentation
+- **Serves:** https://docs.opensin.ai
+- **Owns:** all end-user documentation (guides, tutorials, API reference, install).
+- **Not:** organizational / onboarding material. That lives here in `OpenSIN-overview`.
+
+---
+
+## 5. Infrastructure & Setup
+
+### Infra-SIN-Dev-Setup — Everything-to-get-running repo
+- **URL:** https://github.com/OpenSIN-AI/Infra-SIN-Dev-Setup
+- **Domain prefix:** `Infra-SIN-*`
+- **Owns:**
+  - Developer environment setup — macOS, OCI, CloudFlare, OpenCode, Docker build
+  - End-user first-run setup at `user-onboarding/` (absorbed from archived `OpenSIN-onboarding` repo)
+- **Do not:** create a separate repo for new setup automation. Add it here.
+
+---
+
+## 6. Marketing & Launch
+
+### Biz-SIN-Marketing — Launch hub and community strategy
+- **URL:** https://github.com/OpenSIN-AI/Biz-SIN-Marketing (was `OpenSIN-Marketing-Release-Strategie`)
+- **Domain prefix:** `Biz-SIN-*`
+- **Owns:** blog posts, launch plan, press release, social media calendar, demo scripts. Source of truth for marketing copy.
+- **Authoritative numbers live in `OpenSIN-overview/registry/`**, not in Marketing READMEs. Marketing consumes them.
+
+---
+
+## 7. Organizational meta repos
+
+### OpenSIN-overview — Organizational SSOT (this repo)
+- **URL:** https://github.com/OpenSIN-AI/OpenSIN-overview
+- **Owns:** onboarding, repo registry, boundary rules, consolidation reports, naming conventions, agent lexicon.
+- **Does not own:** production code. Link to owning repos for runtime / docs / product / control-plane details.
+
+---
+
+## 8. External SSOT dependencies
+
+These repos live in **@Delqhi (personal org)** but are declared as SSOT by
+at least six OpenSIN-AI repos in their own READMEs. The current arrangement
+is fragile — any change to these repos affects the org without going
+through OpenSIN-AI governance.
+
+### Delqhi/upgraded-opencode-stack
+- **URL:** https://github.com/Delqhi/upgraded-opencode-stack
+- **Role:** canonical OpenCode configuration consumed via `sin-sync` by OpenSIN, OpenSIN-Code, OpenSIN-WebApp, website-opensin.ai, website-my.opensin.ai, Template-SIN-Agent, Biz-SIN-Marketing, OpenSIN-onboarding (archived).
+- **Risk:** not in the OpenSIN-AI organization. One personal account owns it.
+- **Recommendation:** transfer to `OpenSIN-AI/Infra-SIN-OpenCode-Stack` so governance, branch protection, and team reviews apply. Until transferred, treat it as read-only from the OpenSIN-AI side.
+
+### Delqhi/global-brain
+- **URL:** https://github.com/Delqhi/global-brain
+- **Role:** Persistent Code Plan Memory (PCPM v3/v4) daemon. Referenced by agents across the org.
+- **Risk:** same as above.
+- **Recommendation:** transfer to `OpenSIN-AI/Infra-SIN-Global-Brain`.
+
+---
+
+## Naming convention
+
+Two schemes coexist today. **Both are valid, for different reasons.**
+
+### Flagship / product-facing names (no prefix)
+Use the product name as-is:
+- `OpenSIN`
+- `OpenSIN-Code`
+- `OpenSIN-backend`
+- `OpenSIN-WebApp`
+- `OpenSIN-overview`
+- `OpenSIN-documentation`
+- `website-opensin.ai`
+- `website-my.opensin.ai`
+
+These are the repos that a new user, investor, or contributor is expected to find via search. Using the product name directly is the right call.
+
+### Domain-prefix names (`<Domain>-SIN-*`)
+Used for repos that exist only to support the product and would be noise in search:
+
+| Prefix | Meaning | Examples |
+|---|---|---|
+| `Team-SIN-*` | A coding/business team monorepo of sub-agents | `Team-SIN-Code-Core`, `Team-SIN-Google` (planned), `Team-SIN-BugBounty` (planned) |
+| `Infra-SIN-*` | Infrastructure, setup, tooling, CI | `Infra-SIN-Dev-Setup` |
+| `Biz-SIN-*` | Business/marketing/sales content | `Biz-SIN-Marketing`, `Biz-SIN-Blog-Posts` |
+| `Template-SIN-*` | Templates / blueprints | `Template-SIN-Agent` |
+
+### When to pick which scheme
+
+- If it directly defines the product or its install surface → no prefix (`OpenSIN-*` or `website-*`).
+- If it is a supporting artifact → domain prefix (`Infra-SIN-*`, `Biz-SIN-*`, `Team-SIN-*`, `Template-SIN-*`).
+
+Do NOT introduce a third scheme. If you're tempted to, first open an issue in this repo — `repo-proposal: <name>` — and make the case.
+
+---
+
+## Archived repos (April 2026 consolidation)
+
+| Repo | Canonical replacement |
+|---|---|
+| `OpenSIN-AI/A2A-SIN-Coding-CEO` | `Team-SIN-Code-Core/agents/coding-ceo/` |
+| `OpenSIN-AI/A2A-SIN-Code-AI` | `Team-SIN-Code-Core/agents/code-ai/` |
+| `OpenSIN-AI/opensin-ai-code` | `OpenSIN/opensin_agent_platform/` |
+| `OpenSIN-AI/OpenSIN-onboarding` | `Infra-SIN-Dev-Setup/user-onboarding/` |
+
+These stay on GitHub in read-only state for history. Their READMEs point here.
+
+---
 
 ## How to propose a new code repo
 
-Before creating any new `OpenSIN-AI/*` repo, open an issue in **this** repo
-titled `repo-proposal: <name>` answering:
+Before creating any new `OpenSIN-AI/*` repo, open an issue in this repo
+titled `repo-proposal: <name>` answering these four questions:
 
 1. What responsibility does this repo own that no existing canonical repo owns?
 2. Why can it not be a folder inside one of the canonical repos?
-3. Who maintains it?
+3. Which naming scheme does it use (product name or domain prefix) and why?
+4. Who maintains it?
 
-If the answer to (2) is not clearly "because it must be deployed independently
-with its own release cycle and a different language or runtime," the answer
-is usually: **make it a folder, not a repo.**
+If the answer to (2) is not clearly **"because it must be deployed
+independently, with its own release cycle, and a different language or
+runtime than the candidate parent repo"** — the answer is: **make it a
+folder, not a repo.**

--- a/docs/CONSOLIDATION-2026-04.md
+++ b/docs/CONSOLIDATION-2026-04.md
@@ -2,77 +2,95 @@
 
 ## Problem
 
-The OpenSIN-AI organization had accumulated multiple repos that all claimed
-to be "the coding / agent platform." Concretely:
+The OpenSIN-AI organization had accumulated duplicated, ambiguously-owned, and
+wrongly-located repos across four distinct failure modes:
 
-- Three repos for the coding-team agents (`Team-SIN-Code-Core`,
-  `A2A-SIN-Coding-CEO`, `A2A-SIN-Code-AI`) that only differed in the
-  model name in `agent.json` and shared a `workspace:*` dependency that
-  could never resolve across repo boundaries.
-- A separate `opensin-ai-code` Python repo that duplicated the ground
-  already covered by `OpenSIN/opensin_core` / `opensin_cli` / `opensin_sdk`,
-  and which advertised a `pip install opensin-ai-code` path that never
-  actually worked (no `pyproject.toml`).
+1. **Split siblings:** three near-identical repos for the coding-team agents that were designed for a pnpm workspace but lived in separate repositories, so the `workspace:*` dependencies could never resolve.
+2. **Duplicated Python platforms:** a standalone `opensin-ai-code` repo claimed to be "the Python Agent Development Platform" while the `OpenSIN` monolith already shipped `opensin_core` / `opensin_cli` / `opensin_api` / `opensin_sdk`.
+3. **Split setup repos:** `Infra-SIN-Dev-Setup` (developer environment) and `OpenSIN-onboarding` (end-user first-run) owned the same domain with different audiences.
+4. **Ambiguous web surface + stale marketing copy:** `OpenSIN-WebApp` had no GitHub description and was easily confused with `website-my.opensin.ai`. `Biz-SIN-Marketing` advertised hard-coded counts ("372 Packages · 620 Agent Teams · 79 Blog Posts") that contradicted `OpenSIN`'s own description ("310+ packages") and were internally inconsistent.
 
-Result: new contributors (human and agent) could not tell where new code
-should go, and cross-repo workspace dependencies were fundamentally broken.
+## Wave 1 — agent and platform merges
 
-## Actions taken
-
-### 1. Coding-team monorepo
+### 1.1 Coding-team monorepo
 Merged into `OpenSIN-AI/Team-SIN-Code-Core`:
 - `A2A-SIN-Coding-CEO` → `agents/coding-ceo/`
 - `A2A-SIN-Code-AI` → `agents/code-ai/`
 
-Added `pnpm-workspace.yaml`, `packages/shared-helpers/` (the previously
-missing workspace:* target), and `start:coding-ceo` / `start:code-ai`
-scripts in the root `package.json`.
+Added `pnpm-workspace.yaml`, `packages/shared-helpers/` (previously-missing `workspace:*` target), and `start:coding-ceo` / `start:code-ai` scripts.
 
-PR: https://github.com/OpenSIN-AI/Team-SIN-Code-Core/pull/2
+**PR:** https://github.com/OpenSIN-AI/Team-SIN-Code-Core/pull/2 — merged.
 
-### 2. Python platform merge
-Merged `opensin-ai-code` into `OpenSIN` as `opensin_agent_platform/`.
-Folder is preserved as reference material with a follow-up rationalization
-plan documented in its README. Not yet wired into the production build.
+### 1.2 Python platform merge
+Merged `opensin-ai-code` → `OpenSIN/opensin_agent_platform/`. Preserved source tree; rationalization plan documented in the new folder's README. Not yet wired into production build.
 
-PR: https://github.com/OpenSIN-AI/OpenSIN/pull/1720
+**PR:** https://github.com/OpenSIN-AI/OpenSIN/pull/1720 — merged.
 
-### 3. Onboarding SSOT
-Sharpened `OpenSIN-overview` with:
-- `START-HERE.md` — 60-second onboarding for humans and agents
-- `docs/CANONICAL-REPOS.md` — authoritative repo-ownership map
-- This report
+### 1.3 Initial onboarding SSOT
+Added to `OpenSIN-overview`:
+- `START-HERE.md`
+- `docs/CANONICAL-REPOS.md` (initial version)
+- `docs/CONSOLIDATION-2026-04.md`
 
-### 4. Archival
-After the two PRs above merge, the following repos are archived with a
-redirect README:
-- `OpenSIN-AI/A2A-SIN-Coding-CEO`
-- `OpenSIN-AI/A2A-SIN-Code-AI`
-- `OpenSIN-AI/opensin-ai-code`
+**PR:** https://github.com/OpenSIN-AI/OpenSIN-overview/pull/29 — merged.
+
+### 1.4 Wave 1 archival
+- `OpenSIN-AI/A2A-SIN-Coding-CEO` — archived with redirect README.
+- `OpenSIN-AI/A2A-SIN-Code-AI` — archived with redirect README.
+- `OpenSIN-AI/opensin-ai-code` — archived with redirect README.
+
+## Wave 2 — setup merge + surface cleanup
+
+### 2.1 Setup merge
+Merged `OpenSIN-onboarding` → `Infra-SIN-Dev-Setup/user-onboarding/`. New top-level README splits developer vs. end-user paths.
+
+**PR:** https://github.com/OpenSIN-AI/Infra-SIN-Dev-Setup/pull/34
+
+**Redirect PR:** https://github.com/OpenSIN-AI/OpenSIN-onboarding/pull/5
+
+### 2.2 OpenSIN-WebApp clarification
+- Added `Related repos` table to README distinguishing the three web properties (`chat.opensin.ai`, `my.opensin.ai`, `opensin.ai`).
+- Fixed `Delhi/upgraded-opencode-stack` typo → `Delqhi/...`.
+- Set GitHub repo description and homepage (was blank).
+
+**PR:** https://github.com/OpenSIN-AI/OpenSIN-WebApp/pull/13
+
+### 2.3 Marketing factual correction
+- Blog-post badge 79 → 89 (actual disk count).
+- Replaced hard-coded "372 Packages · 620 Agent Teams" with a qualitative claim + pointer to `OpenSIN-overview/registry/` as the future SSOT for numbers.
+- Quick Links: `OpenSIN-Code` is the Autonomous CLI, not a VS Code Extension.
+
+**PR:** https://github.com/OpenSIN-AI/Biz-SIN-Marketing/pull/60
+
+### 2.4 Canonical map expansion
+- `docs/CANONICAL-REPOS.md` expanded from 6 entries (wave 1) to ~14 entries covering: Python kernel, coding surface, web surface (3), documentation, infra (merged), marketing, templates, org meta, external SSOT.
+- Added explicit **Naming convention** section documenting the two schemes (flagship vs. domain-prefix) and when to use each.
+- Added a **repo-proposal gate** — four questions that must be answered before creating any new `OpenSIN-AI/*` repo.
+- `START-HERE.md` updated to match the expanded map, with a Delqhi SSOT callout.
+
+**This PR** — https://github.com/OpenSIN-AI/OpenSIN-overview/pull/<this>
+
+### 2.5 Wave 2 archival
+- `OpenSIN-AI/OpenSIN-onboarding` — archived with redirect README.
 
 ## Result
 
-From 9 confusing repos with overlapping claims to 4 code repos + 2 meta
-repos with clearly separated ownership:
-
 | Before | After |
 |---|---|
-| OpenSIN | OpenSIN (unchanged role) |
-| OpenSIN-Code | OpenSIN-Code (unchanged role) |
-| OpenSIN-backend | OpenSIN-backend (unchanged role) |
-| Team-SIN-Code-Core | Team-SIN-Code-Core (now monorepo) |
-| A2A-SIN-Coding-CEO | archived → `Team-SIN-Code-Core/agents/coding-ceo` |
-| A2A-SIN-Code-AI | archived → `Team-SIN-Code-Core/agents/code-ai` |
-| opensin-ai-code | archived → `OpenSIN/opensin_agent_platform` |
-| OpenSIN-overview | OpenSIN-overview (now with START-HERE.md) |
-| OpenSIN-documentation | OpenSIN-documentation (unchanged role) |
+| 9 overlapping code repos | 4 code repos + clearly-split web surface (3) + infra (1) + template (1) + marketing (1) + 2 meta = 12 distinct, non-overlapping repos |
+| 4 archived Wave-1+2 | `A2A-SIN-Coding-CEO`, `A2A-SIN-Code-AI`, `opensin-ai-code`, `OpenSIN-onboarding` |
 
 ## Follow-ups
 
-1. Diff `OpenSIN/opensin_agent_platform/` against `OpenSIN/opensin_core/`
-   (both have `hooks`, `plugins`, `skills` modules). Port any genuinely
-   useful logic into `opensin_core` and retire the folder.
-2. Extend `Team-SIN-Code-Core` with `agents/code-devops/` and
-   `agents/code-datascience/` instead of creating new repos for them.
-3. Run `discover-agents.js` and `registry/MASTER_INDEX.md` regeneration
-   so the indexes reflect the new layout.
+### Governance
+1. **Transfer `Delqhi/upgraded-opencode-stack` and `Delqhi/global-brain` to OpenSIN-AI.** Six+ repos declare these as SSOT in their READMEs. They must live under the same governance as the repos that depend on them.
+
+### Rationalization
+2. Diff `OpenSIN/opensin_agent_platform/` against `OpenSIN/opensin_core/` (both have `hooks`, `plugins`, `skills`). Port genuinely useful logic into `opensin_core` and retire the folder.
+
+### Content
+3. Regenerate `OpenSIN-overview/registry/MASTER_INDEX.md` and `platforms/registry.json` to reflect post-wave-2 layout.
+4. Run a link-fixer across all README files: find every reference to the archived repos (`A2A-SIN-Coding-CEO`, `A2A-SIN-Code-AI`, `opensin-ai-code`, `OpenSIN-onboarding`) and replace with the canonical target from `docs/CANONICAL-REPOS.md`.
+
+### Expansion
+5. When adding `Team-SIN-Google`, `Team-SIN-BugBounty`, etc. — they go as folders under the existing `Team-SIN-*` monorepo that owns their domain, NOT as standalone repos. See the repo-proposal gate in `docs/CANONICAL-REPOS.md`.


### PR DESCRIPTION
## Summary

Wave-2 update to the organizational SSOT. Three files updated; no existing rules are removed.

### START-HERE.md
Now lists every canonical repo (14) grouped by domain — previous version covered 6. New devs and agents were landing in repos that were invisible to the SSOT. Also mentions the Delqhi external dependencies explicitly.

### docs/CANONICAL-REPOS.md
Rewritten as a full authoritative map. New material:
- Per-repo `owns` / `do not` rules
- Three-way split of the web surface (`opensin.ai` / `my.opensin.ai` / `chat.opensin.ai`) that had been confusing even our own READMEs
- Delqhi SSOT flag (§8) calling out that `upgraded-opencode-stack` and `global-brain` live outside the org despite being declared SSOT by 6+ repos
- **Naming convention** section that writes down when to use a flagship name vs. a domain prefix (`Team-SIN-*`, `Infra-SIN-*`, `Biz-SIN-*`, `Template-SIN-*`)
- **Repo-proposal gate**: 4 questions that must be answered before creating any new `OpenSIN-AI/*` repo

### docs/CONSOLIDATION-2026-04.md
Adds the Wave-2 section: onboarding merge, WebApp clarification, marketing numeric correction, canonical map expansion, and archival of `OpenSIN-onboarding`. Plus a Follow-ups section covering Delqhi transfer, `opensin_agent_platform` rationalization, registry regeneration, link-fixing, and the rule that future `Team-SIN-*` groups go as folders inside the existing monorepo.

Related wave-2 PRs:
- https://github.com/OpenSIN-AI/Infra-SIN-Dev-Setup/pull/34 (absorb onboarding)
- https://github.com/OpenSIN-AI/OpenSIN-onboarding/pull/5 (redirect)
- https://github.com/OpenSIN-AI/OpenSIN-WebApp/pull/13 (clarify surface + typo)
- https://github.com/OpenSIN-AI/Biz-SIN-Marketing/pull/60 (numeric drift fix)

Co-authored-by: v0[bot] <v0[bot]@users.noreply.github.com>