### PR TITLE
chore(ssot): link-fix sweep for 4 archived repos + new canonical-repos.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ Bei grossen Codebases (100k+ Zeilen, 1000+ Dateien) MUESSEN Agenten **5-10 paral
 | [OpenSIN](https://github.com/OpenSIN-AI/OpenSIN) | Free/Open-Source Core Engine — Python (QueryEngine, Hooks, Tools, MCP, Sandbox, Memory, A2A) |
 | [OpenSIN-Code](https://github.com/OpenSIN-AI/OpenSIN-Code) | Autonomes CLI + SDK (`@opensin/sdk`) — Agent Loop, Tool System, Model Routing, Memory, Safety, A2A Transport Layer + Rust Engine (71 Dateien, 37.7K Zeilen) |
 | [opensin-ai-cli](https://github.com/OpenSIN-AI/opensin-ai-cli) | **NEU (April 2026)** — AI Coding Assistant in Rust (70 Dateien, 34.601 Zeilen, 9 Crates) |
-| [opensin-ai-code](https://github.com/OpenSIN-AI/opensin-ai-code) | **NEU (April 2026)** — Python Agent Development Platform (100 Dateien, 2.386 Zeilen, 26 Subsysteme) |
 | [opensin-ai-platform](https://github.com/OpenSIN-AI/opensin-ai-platform) | **NEU (April 2026)** — Plugin Ecosystem & GitHub Automation (182 Dateien, 87.247 Zeilen, 14 Plugins) |
 | [OpenSIN-backend](https://github.com/OpenSIN-AI/OpenSIN-backend) | Closed Source Backend — A2A Fleet Control Plane, n8n-Routing, Agenten-Orchestrierung, API für OpenSIN-WebApp |
 | [OpenSIN-WebApp](https://github.com/OpenSIN-AI/OpenSIN-WebApp) | User WebApp (Next.js, Vercel ✅) — Login, Dashboard, Agenten-Steuerung (gekoppelt an OpenSIN-backend) |
@@ -253,6 +252,8 @@ Bei grossen Codebases (100k+ Zeilen, 1000+ Dateien) MUESSEN Agenten **5-10 paral
 → [Vollständige Box Storage Doku](https://github.com/OpenSIN-AI/Infra-SIN-Dev-Setup/blob/main/box-storage.md)
 
 ## 🛠️ INFRA & TOOLS
+> **Note:** As of April 2026, `OpenSIN-onboarding` has been consolidated into `Infra-SIN-Dev-Setup/user-onboarding/`. See [docs/CANONICAL-REPOS.md](./docs/CANONICAL-REPOS.md) for the complete archival map.
+
 
 | Repo | Zweck |
 |------|-------|
@@ -261,7 +262,6 @@ Bei grossen Codebases (100k+ Zeilen, 1000+ Dateien) MUESSEN Agenten **5-10 paral
 | [Core-SIN-Control-Plane](https://github.com/OpenSIN-AI/Core-SIN-Control-Plane) | Doctor/Preflight/Eval Layer |
 | [Infra-SIN-Docker-Empire](https://github.com/OpenSIN-AI/Infra-SIN-Docker-Empire) | 26-Container Docker Infrastruktur |
 | [Infra-SIN-Dev-Setup](https://github.com/OpenSIN-AI/Infra-SIN-Dev-Setup) | Development Environment Setup + Box Storage Guide |
-| [OpenSIN-onboarding](https://github.com/OpenSIN-AI/OpenSIN-onboarding) | Autonomous 6-phase onboarding — GCP, Passwordmanager, Chrome Extension, Box/Drive Setup |
 | [cloud-backend](https://github.com/OpenSIN-AI/cloud-backend) | 🔒 Proprietär: Stripe, OAuth, Premium-API |
 
 ---
@@ -274,7 +274,6 @@ Bei grossen Codebases (100k+ Zeilen, 1000+ Dateien) MUESSEN Agenten **5-10 paral
 | [OpenSIN-documentation](https://github.com/OpenSIN-AI/OpenSIN-documentation) | Offizielle Doku (VitePress) — docs.opensin.ai |
 | [OpenSIN-Code](https://github.com/OpenSIN-AI/OpenSIN-Code) | Core Engine Doku: [OpenSIN Code](https://docs.opensin.ai/docs/guide/opensin-code), [Rust Engine](https://docs.opensin.ai/docs/guide/opensin-code-rust-engine), [Plugins](https://docs.opensin.ai/docs/plugins/opensin-code-plugins) |
 | [opensin-ai-cli](https://github.com/OpenSIN-AI/opensin-ai-cli) | **NEU** — [OpenSIN-AI CLI Doku](https://docs.opensin.ai/docs/guide/opensin-ai-cli) |
-| [opensin-ai-code](https://github.com/OpenSIN-AI/opensin-ai-code) | **NEU** — [OpenSIN-AI Code Doku](https://docs.opensin.ai/docs/guide/opensin-ai-code) |
 | [opensin-ai-platform](https://github.com/OpenSIN-AI/opensin-ai-platform) | **NEU** — [OpenSIN-AI Platform Doku](https://docs.opensin.ai/docs/guide/opensin-ai-platform) |
 
 ---

--- a/platforms/canonical-repos.json
+++ b/platforms/canonical-repos.json
@@ -1,0 +1,57 @@
+{
+  "version": "2.0.0",
+  "updated": "2026-04-18",
+  "description": "Canonical repo registry for OpenSIN-AI. Mirrors docs/CANONICAL-REPOS.md in machine-readable form. For the full 188-repo inventory see registry/MASTER_INDEX.md.",
+  "schema": {
+    "canonical_repos": "Production-owning repos, grouped by domain",
+    "archived": "Repos consolidated into canonical targets; read-only",
+    "external_ssot": "Repos outside OpenSIN-AI that are declared SSOT by OpenSIN-AI repos"
+  },
+  "canonical_repos": {
+    "core_platform": [
+      { "repo": "OpenSIN-AI/OpenSIN", "language": "python", "role": "python_kernel", "packages": ["opensin_core", "opensin_cli", "opensin_api", "opensin_sdk", "opensin_agent_platform"] }
+    ],
+    "autonomous_coding": [
+      { "repo": "OpenSIN-AI/OpenSIN-Code",      "language": "typescript", "role": "autonomous_cli" },
+      { "repo": "OpenSIN-AI/OpenSIN-backend",   "language": "typescript", "role": "a2a_control_plane" },
+      { "repo": "OpenSIN-AI/Team-SIN-Code-Core","language": "typescript", "role": "coding_team_monorepo", "agents": ["coding-ceo", "code-ai"] },
+      { "repo": "OpenSIN-AI/Template-SIN-Agent","language": "typescript", "role": "agent_blueprint" }
+    ],
+    "web_surface": [
+      { "repo": "OpenSIN-AI/website-opensin.ai",    "language": "typescript", "role": "oss_marketing",    "deployed_at": "opensin.ai" },
+      { "repo": "OpenSIN-AI/website-my.opensin.ai", "language": "typescript", "role": "paid_marketing",   "deployed_at": "my.opensin.ai" },
+      { "repo": "OpenSIN-AI/OpenSIN-WebApp",        "language": "typescript", "role": "auth_dashboard",   "deployed_at": "chat.opensin.ai", "package": "opensin-chat" }
+    ],
+    "documentation": [
+      { "repo": "OpenSIN-AI/OpenSIN-documentation", "role": "public_docs", "deployed_at": "docs.opensin.ai" }
+    ],
+    "infrastructure": [
+      { "repo": "OpenSIN-AI/Infra-SIN-Dev-Setup", "role": "dev_and_user_onboarding", "subdirs": ["user-onboarding"] }
+    ],
+    "business": [
+      { "repo": "OpenSIN-AI/Biz-SIN-Marketing", "role": "launch_hub_and_content" }
+    ],
+    "meta": [
+      { "repo": "OpenSIN-AI/OpenSIN-overview", "role": "organizational_ssot" }
+    ]
+  },
+  "archived": [
+    { "repo": "OpenSIN-AI/A2A-SIN-Coding-CEO", "replaced_by": "OpenSIN-AI/Team-SIN-Code-Core/agents/coding-ceo/", "archived_at": "2026-04-18" },
+    { "repo": "OpenSIN-AI/A2A-SIN-Code-AI",    "replaced_by": "OpenSIN-AI/Team-SIN-Code-Core/agents/code-ai/",    "archived_at": "2026-04-18" },
+    { "repo": "OpenSIN-AI/opensin-ai-code",    "replaced_by": "OpenSIN-AI/OpenSIN/opensin_agent_platform/",       "archived_at": "2026-04-18" },
+    { "repo": "OpenSIN-AI/OpenSIN-onboarding", "replaced_by": "OpenSIN-AI/Infra-SIN-Dev-Setup/user-onboarding/",  "archived_at": "2026-04-18" }
+  ],
+  "external_ssot": [
+    { "repo": "Delqhi/upgraded-opencode-stack", "role": "opencode_config_ssot",   "declared_by": ["OpenSIN", "OpenSIN-Code", "OpenSIN-WebApp", "website-opensin.ai", "website-my.opensin.ai", "Template-SIN-Agent", "Biz-SIN-Marketing"], "transfer_status": "pending", "target": "OpenSIN-AI/Infra-SIN-OpenCode-Stack" },
+    { "repo": "Delqhi/global-brain",            "role": "pcpm_v4_daemon",         "declared_by": ["multiple A2A-SIN-* agents"], "transfer_status": "pending", "target": "OpenSIN-AI/Infra-SIN-Global-Brain" }
+  ],
+  "naming_convention": {
+    "flagship_no_prefix": ["OpenSIN", "OpenSIN-Code", "OpenSIN-backend", "OpenSIN-WebApp", "OpenSIN-overview", "OpenSIN-documentation", "website-opensin.ai", "website-my.opensin.ai"],
+    "domain_prefixes": {
+      "Team-SIN-*":     "Team monorepos of sub-agents",
+      "Infra-SIN-*":    "Infrastructure, setup, tooling, CI",
+      "Biz-SIN-*":      "Business/marketing/sales content",
+      "Template-SIN-*": "Templates / blueprints"
+    }
+  }
+}

--- a/registry/MASTER_INDEX.md
+++ b/registry/MASTER_INDEX.md
@@ -1,7 +1,9 @@
 # 📚 THE ULTIMATE MASTER INDEX (187 REPOS)
 
-**LAST UPDATED:** 2026-04-17 03:00 UTC
+**LAST UPDATED:** 2026-04-18 (post-wave-2 consolidation)
 **TOTAL REPOSITORIES:** 188 (42 public, 146 private)
+
+> **Archival note:** 4 repos were consolidated into canonical monorepos in April 2026 and are marked `ARCHIVED` below. See [docs/CANONICAL-REPOS.md](../docs/CANONICAL-REPOS.md) for the canonical ownership map.
 
 Dieses Dokument ist das vollständige, lückenlose Inventar der OpenSIN-AI Organisation. **Jedes** der 187 Repositories ist hier kategorisiert und logisch in die Architektur integriert.
 
@@ -103,11 +105,11 @@ Dieses Dokument ist das vollständige, lückenlose Inventar der OpenSIN-AI Organ
 | [A2A-SIN-CI-CD](https://github.com/OpenSIN-AI/A2A-SIN-CI-CD) | 🔒 Private | SIN A2A component: CI/CD pipeline integration — automated build and deploy. |
 | [A2A-SIN-Chatroom](https://github.com/OpenSIN-AI/A2A-SIN-Chatroom) | 🌐 Public | SIN A2A component: Chatroom integration — multi-platform chat management. |
 | [A2A-SIN-ClaimWriter](https://github.com/OpenSIN-AI/A2A-SIN-ClaimWriter) | 🔒 Private | SIN A2A component: A2A-SIN-ClaimWriter |
-| [A2A-SIN-Code-AI](https://github.com/OpenSIN-AI/A2A-SIN-Code-AI) | 🔒 Private | SIN A2A component: sin-code-ai |
+| [A2A-SIN-Code-AI](https://github.com/OpenSIN-AI/A2A-SIN-Code-AI) | 🔒 Private | ⚠️ **ARCHIVED 2026-04** → consolidated into `Team-SIN-Code-Core/agents/code-ai/` |
 | [A2A-SIN-Code-DataScience](https://github.com/OpenSIN-AI/A2A-SIN-Code-DataScience) | 🔒 Private | SIN A2A component: sin-code-datascience |
 | [A2A-SIN-Code-DevOps](https://github.com/OpenSIN-AI/A2A-SIN-Code-DevOps) | 🔒 Private | SIN A2A component: sin-code-devops |
 | [A2A-SIN-Code-GitLab-LogsCenter](https://github.com/OpenSIN-AI/A2A-SIN-Code-GitLab-LogsCenter) | 🔒 Private | Autonomous log analysis agent: monitors GitLab LogCenter repos, detects errors/bugs via pattern analysis, auto-creates GitHub issues, dispatches fixes to Team Coding |
-| [A2A-SIN-Coding-CEO](https://github.com/OpenSIN-AI/A2A-SIN-Coding-CEO) | 🔒 Private | SIN A2A component: sin-coding-ceo |
+| [A2A-SIN-Coding-CEO](https://github.com/OpenSIN-AI/A2A-SIN-Coding-CEO) | 🔒 Private | ⚠️ **ARCHIVED 2026-04** → consolidated into `Team-SIN-Code-Core/agents/coding-ceo/` |
 | [A2A-SIN-Community](https://github.com/OpenSIN-AI/A2A-SIN-Community) | 🔒 Private | OpenSIN Marketing Agent for Community - Autonomous cold outreach, lead scraping, and engagement |
 | [A2A-SIN-Compliance](https://github.com/OpenSIN-AI/A2A-SIN-Compliance) | 🔒 Private | SIN A2A component: A2A-SIN-Compliance |
 | [A2A-SIN-Contract](https://github.com/OpenSIN-AI/A2A-SIN-Contract) | 🔒 Private | SIN A2A component: A2A-SIN-Contract |
@@ -294,12 +296,11 @@ Dieses Dokument ist das vollständige, lückenlose Inventar der OpenSIN-AI Organ
 | [OpenSIN](https://github.com/OpenSIN-AI/OpenSIN) | 🌐 Public | OpenSIN Core — 310+ packages across 25+ domains. The most comprehensive open-source AI agent system in the world. |
 | [OpenSIN-documentation](https://github.com/OpenSIN-AI/OpenSIN-documentation) | 🌐 Public | Official documentation for OpenSIN - docs.opensin.ai |
 | [OpenSIN-github-apps](https://github.com/OpenSIN-AI/OpenSIN-github-apps) | 🔒 Private | Central registry, documentation, and routing configurations for all OpenSIN-AI GitHub Apps |
-| [OpenSIN-onboarding](https://github.com/OpenSIN-AI/OpenSIN-onboarding) | 🌐 Public | Autonomous first-run onboarding for OpenSIN — sets up Passwordmanager, Google Cloud Secrets, Chrome Extension, API keys, and platform accounts with zero manual intervention |
+| [OpenSIN-onboarding](https://github.com/OpenSIN-AI/OpenSIN-onboarding) | 🌐 Public | ⚠️ **ARCHIVED 2026-04** → consolidated into `Infra-SIN-Dev-Setup/user-onboarding/` |
 | [OpenSIN-overview](https://github.com/OpenSIN-AI/OpenSIN-overview) | 🌐 Public | The Ultimate Single Source of Truth for the OpenSIN-AI organization (Rules, Teams, Agents, MCPs) |
 | [SIN-InkogniFlow](https://github.com/OpenSIN-AI/SIN-InkogniFlow) | 🔒 Private | Cloneable flow-builder repo with sin-flow and sin-flowd |
 | [awesome-opensin](https://github.com/OpenSIN-AI/awesome-opensin) | 🌐 Public | A curated list of awesome plugins, themes, agents, projects, and resources for https://opencode.ai |
 | [documentation](https://github.com/OpenSIN-AI/documentation) | 🔒 Private | ⚠️ ARCHIVED — All docs migrated to github.com/OpenSIN-AI/OpenSIN-documentation |
 | [opensin-ai-cli](https://github.com/OpenSIN-AI/opensin-ai-cli) | 🌐 Public | OpenSIN-AI opensin-ai-cli |
-| [opensin-ai-code](https://github.com/OpenSIN-AI/opensin-ai-code) | 🌐 Public | OpenSIN-AI opensin-ai-code |
+| [opensin-ai-code](https://github.com/OpenSIN-AI/opensin-ai-code) | 🌐 Public | ⚠️ **ARCHIVED 2026-04** → consolidated into `OpenSIN/opensin_agent_platform/` |
 | [opensin-ai-platform](https://github.com/OpenSIN-AI/opensin-ai-platform) | 🌐 Public | OpenSIN-AI opensin-ai-platform |
-


### PR DESCRIPTION
## Summary

Three surfaces in this repo still pointed at the 4 archived repos as if they were live. This PR fixes that and ships the first machine-readable version of the canonical repo map.

### README.md
- Remove stale rows for `opensin-ai-code` (x2) and `OpenSIN-onboarding` from the Core Engine / Infra / Doku tables
- Rename `OpenSIN-Marketing-Release-Strategie` -> `Biz-SIN-Marketing` (repo was renamed)
- Rename `Template-A2A-SIN-Agent` -> `Template-SIN-Agent` (repo was renamed)
- Archival note at the head of the Infra section

### registry/MASTER_INDEX.md
- 4 archived repo rows marked `ARCHIVED 2026-04 -> consolidated into <target>` in place (history preserved, next reader sees the redirect immediately)
- Timestamp updated, archival note added under the header

### platforms/canonical-repos.json (new)
- Machine-readable mirror of `docs/CANONICAL-REPOS.md`
- 7 domains, 12 canonical repos, 4 archived, 2 external SSOT
- Intended for agent tooling — if you are building `discover-agents.js` or similar, consume this file
- `platforms/registry.json` (the existing webhook-intake config) is left **unchanged**; the two files have different purposes

Co-authored-by: v0[bot] <v0[bot]@users.noreply.github.com>