### PR TITLE
docs(ssot): Delqhi -> OpenSIN-AI governance transfer complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 > 📊 **195 Repositories** | **17 Teams** | **149 Worker** | **4 Templates** | **44 Skills** | **6 Websites**
 
 > [!IMPORTANT]
-> **SSOT:** Die kanonische OpenCode-Konfiguration liegt unter [Delqhi/upgraded-opencode-stack](https://github.com/Delqhi/upgraded-opencode-stack) (v2.2.1, 44 Skills, 27 MCPs, 5 Provider).
+> **SSOT:** Die kanonische OpenCode-Konfiguration liegt unter [OpenSIN-AI/Infra-SIN-OpenCode-Stack](https://github.com/OpenSIN-AI/Infra-SIN-OpenCode-Stack) (v2.2.1, 44 Skills, 27 MCPs, 5 Provider).
 > Nach jeder Änderung an `opencode.json` MUSS `sin-sync` ausgeführt werden.
 
 ---

--- a/START-HERE.md
+++ b/START-HERE.md
@@ -34,7 +34,7 @@ Lies in dieser Reihenfolge:
 3. **`platforms/registry.json`** — structured repo list.
 4. **`AGENTS.md`** + **`governance/BOUNDARY-ROLE-RULES.md`** — rules you must follow.
 
-Vor jedem Task: `discover-agents.js` ausführen (Routing-Regeln siehe `opencode.json` bei `Delqhi/upgraded-opencode-stack` — which is the external SSOT for OpenCode config; see CANONICAL-REPOS.md § 8).
+Vor jedem Task: `discover-agents.js` ausführen (Routing-Regeln siehe `opencode.json` bei `OpenSIN-AI/Infra-SIN-OpenCode-Stack` — which is the external SSOT for OpenCode config; see CANONICAL-REPOS.md § 8).
 
 ---
 
@@ -83,8 +83,8 @@ Vor jedem Task: `discover-agents.js` ausführen (Routing-Regeln siehe `opencode.
 ### Externe SSOT (noch in @Delqhi — sollten transferiert werden)
 | Repo | Rolle |
 |---|---|
-| [Delqhi/upgraded-opencode-stack](https://github.com/Delqhi/upgraded-opencode-stack) | Kanonische OpenCode-Konfiguration (sin-sync Target) |
-| [Delqhi/global-brain](https://github.com/Delqhi/global-brain) | PCPM v4 daemon (persistent agent memory) |
+| [OpenSIN-AI/Infra-SIN-OpenCode-Stack](https://github.com/OpenSIN-AI/Infra-SIN-OpenCode-Stack) | Kanonische OpenCode-Konfiguration (sin-sync Target) |
+| [OpenSIN-AI/Infra-SIN-Global-Brain](https://github.com/OpenSIN-AI/Infra-SIN-Global-Brain) | PCPM v4 daemon (persistent agent memory) |
 
 ---
 

--- a/docs/CANONICAL-REPOS.md
+++ b/docs/CANONICAL-REPOS.md
@@ -117,24 +117,21 @@ Three repos for three distinct properties. Do not confuse them.
 
 ---
 
-## 8. External SSOT dependencies
+## 8. Infrastructure SSOT (formerly external — now in-org)
 
-These repos live in **@Delqhi (personal org)** but are declared as SSOT by
-at least six OpenSIN-AI repos in their own READMEs. The current arrangement
-is fragile — any change to these repos affects the org without going
-through OpenSIN-AI governance.
+Two infrastructure repos that are declared SSOT by many other repos across the org. As of 2026-04-18 both were transferred from the personal `Delqhi` account to `OpenSIN-AI` and renamed per the `Infra-SIN-*` convention, so they now inherit org-level branch protection, team reviews, and audit logs.
 
-### Delqhi/upgraded-opencode-stack
-- **URL:** https://github.com/Delqhi/upgraded-opencode-stack
-- **Role:** canonical OpenCode configuration consumed via `sin-sync` by OpenSIN, OpenSIN-Code, OpenSIN-WebApp, website-opensin.ai, website-my.opensin.ai, Template-SIN-Agent, Biz-SIN-Marketing, OpenSIN-onboarding (archived).
-- **Risk:** not in the OpenSIN-AI organization. One personal account owns it.
-- **Recommendation:** transfer to `OpenSIN-AI/Infra-SIN-OpenCode-Stack` so governance, branch protection, and team reviews apply. Until transferred, treat it as read-only from the OpenSIN-AI side.
+### OpenSIN-AI/Infra-SIN-OpenCode-Stack
+- **URL:** https://github.com/OpenSIN-AI/Infra-SIN-OpenCode-Stack
+- **Legacy path (redirects):** `Delqhi/upgraded-opencode-stack`
+- **Role:** canonical OpenCode configuration (v2.2.1, 44 skills, 27 MCPs, 5 providers) consumed via `sin-sync` by: OpenSIN, OpenSIN-Code, OpenSIN-WebApp, website-opensin.ai, website-my.opensin.ai, Template-SIN-Agent, Biz-SIN-Marketing.
 
-### Delqhi/global-brain
-- **URL:** https://github.com/Delqhi/global-brain
-- **Role:** Persistent Code Plan Memory (PCPM v3/v4) daemon. Referenced by agents across the org.
-- **Risk:** same as above.
-- **Recommendation:** transfer to `OpenSIN-AI/Infra-SIN-Global-Brain`.
+### OpenSIN-AI/Infra-SIN-Global-Brain
+- **URL:** https://github.com/OpenSIN-AI/Infra-SIN-Global-Brain
+- **Legacy path (redirects):** `Delqhi/global-brain`
+- **Role:** Persistent Code Plan Memory (PCPM v4) daemon. Referenced by all `A2A-SIN-*` agents across the org.
+
+GitHub redirects the old `Delqhi/...` URLs, so any `sin-sync` tooling or older README link continues to resolve. A follow-up link-sweep will update all references to the canonical `OpenSIN-AI/Infra-SIN-*` paths.
 
 ---
 

--- a/docs/CONSOLIDATION-2026-04.md
+++ b/docs/CONSOLIDATION-2026-04.md
@@ -83,7 +83,7 @@ Merged `OpenSIN-onboarding` → `Infra-SIN-Dev-Setup/user-onboarding/`. New top-
 ## Follow-ups
 
 ### Governance
-1. **Transfer `Delqhi/upgraded-opencode-stack` and `Delqhi/global-brain` to OpenSIN-AI.** Six+ repos declare these as SSOT in their READMEs. They must live under the same governance as the repos that depend on them.
+1. **Transfer `OpenSIN-AI/Infra-SIN-OpenCode-Stack` and `OpenSIN-AI/Infra-SIN-Global-Brain` to OpenSIN-AI.** Six+ repos declare these as SSOT in their READMEs. They must live under the same governance as the repos that depend on them.
 
 ### Rationalization
 2. Diff `OpenSIN/opensin_agent_platform/` against `OpenSIN/opensin_core/` (both have `hooks`, `plugins`, `skills`). Port genuinely useful logic into `opensin_core` and retire the folder.
@@ -94,3 +94,21 @@ Merged `OpenSIN-onboarding` → `Infra-SIN-Dev-Setup/user-onboarding/`. New top-
 
 ### Expansion
 5. When adding `Team-SIN-Google`, `Team-SIN-BugBounty`, etc. — they go as folders under the existing `Team-SIN-*` monorepo that owns their domain, NOT as standalone repos. See the repo-proposal gate in `docs/CANONICAL-REPOS.md`.
+
+## Wave 2.5 — Governance transfer (completed 2026-04-18)
+
+Transferred the two external SSOT repos from `Delqhi` (personal account) to `OpenSIN-AI` (organization) and renamed them per the canonical `Infra-SIN-*` convention:
+
+| Before | After |
+|---|---|
+| `Delqhi/upgraded-opencode-stack` | `OpenSIN-AI/Infra-SIN-OpenCode-Stack` |
+| `Delqhi/global-brain`            | `OpenSIN-AI/Infra-SIN-Global-Brain` |
+
+**Impact:**
+- Both repos now live under the organization's governance: branch protection, team reviews, audit log.
+- GitHub automatically redirects the old URLs, so `sin-sync` references and the 6+ repo READMEs that cited the old paths continue to work during the transition. They will be updated to the canonical path in a follow-up link-sweep.
+- The transfer fixes the governance gap called out in `docs/CANONICAL-REPOS.md § 8` — the section is rewritten to reflect the new home in this PR.
+
+**Follow-ups:**
+1. Link-sweep: update all repo READMEs that reference the old `Delqhi/...` paths to the new canonical paths (GitHub redirects cover us for now, but we don't want permanent indirection).
+2. Verify `sin-sync` tooling works with the new repo names or uses the GitHub redirect transparently.


### PR DESCRIPTION
## Summary

The two external SSOT repos have been transferred to OpenSIN-AI and renamed per canonical convention:

| Before | After |
|---|---|
| `Delqhi/upgraded-opencode-stack` | `OpenSIN-AI/Infra-SIN-OpenCode-Stack` |
| `Delqhi/global-brain` | `OpenSIN-AI/Infra-SIN-Global-Brain` |

Both now inherit org branch protection, team reviews, audit logs. GitHub auto-redirects old URLs during transition.

## Updates
- `README.md` — SSOT callout link updated
- `START-HERE.md` — SSOT section points at new paths
- `docs/CANONICAL-REPOS.md` — § 8 rewritten as 'Infrastructure SSOT (formerly external — now in-org)'
- `docs/CONSOLIDATION-2026-04.md` — adds Wave 2.5 section

Co-authored-by: v0[bot] <v0[bot]@users.noreply.github.com>